### PR TITLE
Update composer cakephp dependency to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         , "source": "https://github.com/gourmet/money"
     }
     , "require": {
-        "cakephp/cakephp": "3.0.*-dev",
+        "cakephp/cakephp": "3.*",
         "sebastian/money": "1.5.*"
     }
     , "require-dev": {


### PR DESCRIPTION
As CakePHP now has an official 3.x release it is time to update the composer.json to do this.
The current state of the file actually breaks composer installs of the plugin on CakePHP 3 apps.
This currently makes the Money Datatype uninstallable.

Thanks & Cheers,
   Borislav Sabev.
